### PR TITLE
change zip sorting again (#943)

### DIFF
--- a/file_io.cpp
+++ b/file_io.cpp
@@ -1224,12 +1224,6 @@ struct DirentComp
 		if ((de1.de.d_type == DT_DIR) && (de2.de.d_type != DT_DIR)) return true;
 		if ((de1.de.d_type != DT_DIR) && (de2.de.d_type == DT_DIR)) return false;
 
-		if ((de1.de.d_type == DT_DIR) && (de2.de.d_type == DT_DIR))
-		{
-			if (!(de1.flags & DT_EXT_ZIP) && (de2.flags & DT_EXT_ZIP)) return true;
-			if ((de1.flags & DT_EXT_ZIP) && !(de2.flags & DT_EXT_ZIP)) return false;
-		}
-
 		int len1 = strlen(de1.altname);
 		int len2 = strlen(de2.altname);
 		if ((len1 > 4) && (de1.altname[len1 - 4] == '.')) len1 -= 4;

--- a/menu.cpp
+++ b/menu.cpp
@@ -7107,6 +7107,10 @@ void PrintDirectory(int expand)
 			{
 				strncpy(s + 1, flist_DirItem(k)->altname+1, len-1);
 			}
+			else if (flist_DirItem(k)->flags & DT_EXT_ZIP)
+			{
+				strncpy(s + 1, flist_DirItem(k)->altname, len-4); // strip .zip extension, see below
+			}
 			else
 			{
 				strncpy(s + 1, flist_DirItem(k)->altname, len); // display only name
@@ -7122,7 +7126,7 @@ void PrintDirectory(int expand)
 				else
 				{
 					if (flist_DirItem(k)->flags & DT_EXT_ZIP) // mark ZIP archive with different suffix
-						strcpy(&s[22], " <zip>");
+						strcpy(&s[22], " <ZIP>");
 					else
 						strcpy(&s[22], " <DIR>");
 				}


### PR DESCRIPTION
* file_io: sort zips with directories again

* menu: strip now-redundant .zip extension, make <ZIP> suffix match <DIR>